### PR TITLE
Add Google repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
Hello,

Since bc0137717fbd57937d002083891a3a8ebe61dd54, I'm getting the following error when I run `gradle assemble`:
```
Execution failed for task ':app:lintVitalRelease'.
> Could not resolve all files for configuration ':app:lintClassPath'.
   > Could not find com.android.tools.lint:lint-gradle:26.1.2.
     Searched in the following locations:
         file:/home/pierre/lib/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.pom
         file:/home/pierre/lib/android-sdk/extras/m2repository/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.jar
         file:/home/pierre/lib/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.pom
         file:/home/pierre/lib/android-sdk/extras/google/m2repository/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.jar
         file:/home/pierre/lib/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.pom
         file:/home/pierre/lib/android-sdk/extras/android/m2repository/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.jar
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.pom
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.jar
         https://jitpack.io/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.pom
         https://jitpack.io/com/android/tools/lint/lint-gradle/26.1.2/lint-gradle-26.1.2.jar
     Required by:
         project :app
```

This patch fixes it.